### PR TITLE
Ensure indifferent access for subclasses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,29 @@
 PATH
   remote: .
   specs:
-    mongoid-indifferent-access (0.0.1)
+    mongoid-indifferent-access (0.0.3)
       mongoid
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.2)
-      activesupport (= 3.2.2)
+    activemodel (3.2.7)
+      activesupport (= 3.2.7)
       builder (~> 3.0.0)
-    activesupport (3.2.2)
+    activesupport (3.2.7)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    bson (1.6.1)
-    bson (1.6.1-java)
     builder (3.0.0)
     diff-lcs (1.1.3)
     i18n (0.6.0)
-    mongo (1.6.1)
-      bson (~> 1.6.1)
-    mongoid (2.4.6)
+    mongoid (3.0.3)
       activemodel (~> 3.1)
-      mongo (~> 1.3)
+      moped (~> 1.1)
+      origin (~> 1.0)
       tzinfo (~> 0.3.22)
-    multi_json (1.1.0)
+    moped (1.2.0)
+    multi_json (1.3.6)
+    origin (1.0.4)
     rake (0.9.2.2)
     rspec (2.8.0)
       rspec-core (~> 2.8.0)
@@ -34,7 +33,7 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    tzinfo (0.3.32)
+    tzinfo (0.3.33)
 
 PLATFORMS
   java

--- a/lib/mongoid_indifferent_access.rb
+++ b/lib/mongoid_indifferent_access.rb
@@ -2,39 +2,52 @@ module Mongoid
   module Extensions
     module Hash
       module IndifferentAccess
-        VERSION = "0.0.2"
+
+        VERSION = "0.0.3"
 
         def self.included(klass)
           klass.class_eval do
-            # @override Mongoid::Field
+
             def self.field(name, options={})
               field = super(name, options)
 
-              # why oh why does sometimes Hash != Hash? something with my environment maybe?
-              # tried ruby 1.9.2-p290 and jruby 1.6.6 (1.9 mode), so we also try checking the class name
-              if options[:type] == Hash || options[:type].name =~ /Hash/
-                getter_name = name.is_a?(Symbol) ? name : name.intern
-                setter_name = "#{getter_name}=".intern
+              if options[:type].name == 'Hash'
+                getter_name = name.to_sym
+                setter_name = "#{getter_name}=".to_sym
 
-                define_method(getter_name) do
-                  val = super()
-                  unless val.nil? || val.is_a?(HashWithIndifferentAccess)
-                    wrapped_hash = val.with_indifferent_access
-                    self.send(setter_name, wrapped_hash)
-                    val = wrapped_hash
-                  end
-                  val
-                end
+                hia_define_getter(getter_name, setter_name)
+                hia_define_setter(setter_name)
 
-                define_method(setter_name) do |hash|
-                  unless hash.nil? || hash.is_a?(HashWithIndifferentAccess)
-                    hash = hash.with_indifferent_access
-                  end
-                  super(hash)
+                descendants.each do |subclass|
+                  subclass.hia_define_getter(getter_name, setter_name)
+                  subclass.hia_define_setter(setter_name)
                 end
               end
+
               field
             end
+
+            def self.hia_define_getter(getter_name, setter_name)
+              define_method(getter_name) do
+                val = super()
+                unless val.nil? || val.is_a?(HashWithIndifferentAccess)
+                  wrapped_hash = val.with_indifferent_access
+                  self.send(setter_name, wrapped_hash)
+                  val = wrapped_hash
+                end
+                val
+              end
+            end
+
+            def self.hia_define_setter(setter_name)
+              define_method(setter_name) do |hash|
+                unless hash.nil? || hash.is_a?(HashWithIndifferentAccess)
+                  hash = hash.with_indifferent_access
+                end
+                super(hash)
+              end
+            end
+
           end
         end
       end

--- a/mongoid-indifferent-access.gemspec
+++ b/mongoid-indifferent-access.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'mongoid-indifferent-access'
-  s.version           = '0.0.1'
+  s.version           = '0.0.3'
   s.date              = '2012-03-13'
   s.rubyforge_project = 'mongoid-indifferent-access'
 

--- a/spec/mongoid-indifferent-access/indifferent_access_spec.rb
+++ b/spec/mongoid-indifferent-access/indifferent_access_spec.rb
@@ -1,41 +1,69 @@
 require 'spec_helper'
-require 'mongoid_indifferent_access'
-require 'mongoid'
-
-# mocking some of what Mongoid::Document would provide
-# so the spec doesn't require having MongoDB running
-class MockSuper
-  attr_accessor :config
-  def self.field(name, options={})
-    nil
-  end
-end
-
-class Guitar < MockSuper
-  include Mongoid::Extensions::Hash::IndifferentAccess
-
-  field :config, :type => Hash
-end
+require 'support/guitar'
+require 'support/mandalin'
 
 module Mongoid::Extensions::Hash
 
   describe IndifferentAccess do
-    subject {
-      g = Guitar.new
-      g.config = {:value => 123}
-      g
-    }
+
+    before :each do
+      @subject = Guitar.new
+      @subject.config = {:value => 123}
+    end
 
     it "returns a value given a String as the key" do
-      subject.config["value"].should eq(123)
+      @subject.config["value"].should eq(123)
     end
 
     it "returns a value given a Symbol as the key" do
-      subject.config[:value].should eq(123)
+      @subject.config[:value].should eq(123)
     end
 
     it "returns nil given a non-existing key" do
-      subject.config[:non_existant].should be_nil
+      @subject.config[:non_existant].should be_nil
+    end
+
+    describe 'subclasses' do
+
+      before :each do
+        @sub_subject = Mandalin.new
+        @sub_subject.config = {:value => 123}
+      end
+
+      it "returns a value given a String as the key" do
+        @sub_subject.config["value"].should eq(123)
+      end
+
+      it "returns a value given a Symbol as the key" do
+        @sub_subject.config[:value].should eq(123)
+      end
+
+      it "returns nil given a non-existing key" do
+        @sub_subject.config[:non_existant].should be_nil
+      end
+
+      describe 'reload superclass' do
+
+        before :each do
+          load 'support/guitar.rb'
+          @sub_subject = Mandalin.new
+          @sub_subject.config = {:value => 123}
+        end
+
+        it "returns a value given a String as the key" do
+          @sub_subject.config["value"].should eq(123)
+        end
+
+        it "returns a value given a Symbol as the key" do
+          @sub_subject.config[:value].should eq(123)
+        end
+
+        it "returns nil given a non-existing key" do
+          @sub_subject.config[:non_existant].should be_nil
+        end
+
+      end
+
     end
 
   end

--- a/spec/support/guitar.rb
+++ b/spec/support/guitar.rb
@@ -1,0 +1,9 @@
+require 'mongoid'
+require 'mongoid_indifferent_access'
+
+class Guitar
+  include Mongoid::Document
+  include Mongoid::Extensions::Hash::IndifferentAccess
+
+  field :config, :type => Hash
+end

--- a/spec/support/mandalin.rb
+++ b/spec/support/mandalin.rb
@@ -1,0 +1,2 @@
+class Mandalin < Guitar
+end


### PR DESCRIPTION
This pull request adds indifferent access support to subclasses of a class that has included the mongoid-indifferent-access module.  

When Mongoid defines 'field' it automatically defines it for all subclasses.  Since mongoid-indifferent-access did not do this also, there was a situation where a call to load a superclass after a subclass has already been loaded breaks indifferent-access-support for its subclasses.  This happens because the call to 'super' inside mongoid-indifferent-access will define the getters and setters for the current class and all subclasses but mongoid-indifferent-access doesn't redefine these subclasses, it only redefines those of 'self'.  This extraneous case can arise when using Sidekiq with Mongoid as Sidekiq Workers will load rails, then call Rails.application.eager_load!

To ensure that testing for this works, I've removed the MockSuper and now use Mongoid::Document directly which will require MongoDB, but as this gem is called "mongoid"-indifferent-access, I think this is a tradeoff we can live with.

Also includes a version bump
