### PR TITLE
fixing issue where getter throws exception if model is frozen

### DIFF
--- a/lib/mongoid_indifferent_access.rb
+++ b/lib/mongoid_indifferent_access.rb
@@ -32,7 +32,7 @@ module Mongoid
                 val = super()
                 unless val.nil? || val.is_a?(HashWithIndifferentAccess)
                   wrapped_hash = val.with_indifferent_access
-                  self.send(setter_name, wrapped_hash)
+                  self.send(setter_name, wrapped_hash) unless self.frozen?
                   val = wrapped_hash
                 end
                 val

--- a/spec/mongoid-indifferent-access/indifferent_access_spec.rb
+++ b/spec/mongoid-indifferent-access/indifferent_access_spec.rb
@@ -23,6 +23,14 @@ module Mongoid::Extensions::Hash
       @subject.config[:non_existant].should be_nil
     end
 
+    it "getter continues to work when model is frozen" do
+      @subject.attributes["config"] = {}
+      @subject.freeze
+      expect {
+        @subject.config
+      }.to_not raise_error
+    end
+
     describe 'subclasses' do
 
       before :each do


### PR DESCRIPTION
Fix for issue: https://github.com/mindscratch/mongoid-indifferent-access/issues/3

Changes the getter to only try to set the field to HashWithIndifferentAccess (from ordinary Hash) if the model is not frozen.  This allows the getter to continue functioning even if the object is frozen.
